### PR TITLE
Add namespace field in config/rbac/rbac.yaml

### DIFF
--- a/config/rbac/rbac.yaml
+++ b/config/rbac/rbac.yaml
@@ -11,6 +11,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: intel-power-operator
+  namespace: intel-power
 rules:
 - apiGroups:
   - ""
@@ -46,6 +47,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: intel-power-operator
+  namespace: intel-power
 subjects:
 - kind: ServiceAccount
   name: intel-power-operator


### PR DESCRIPTION
- Role is now deployed in the intel-power namespace
- RoleBinding is now deployed in the intel-power namespace

Signed-off-by: Klimowicz, PatrykX <patrykx.klimowicz@intel.com>