### PR TITLE
Kubernetes Power Manager v2.3.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,23 @@ build: generate manifests install
 
 # Build the Manager and Node Agent images
 images: generate manifests install
-	docker build -f build/Dockerfile -t intel/power-operator:v2.3.0 .
-	docker build -f build/Dockerfile.nodeagent -t intel/power-node-agent:v2.3.0 .
+	docker build -f build/Dockerfile -t intel/power-operator:v2.3.1 .
+	docker build -f build/Dockerfile.nodeagent -t intel/power-node-agent:v2.3.1 .
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
 	go run ./main.go
 
 helm-install: generate manifests install
-	helm install kubernetes-power-manager-v2.3.0 ./helm/kubernetes-power-manager-v2.3.0
+	helm install kubernetes-power-manager-v2.3.1 ./helm/kubernetes-power-manager-v2.3.1
 
 helm-uninstall:
+	helm uninstall kubernetes-power-manager-v2.3.1
+
+helm-install-v2.3.0: generate manifests install
+	helm install kubernetes-power-manager-v2.3.0 ./helm/kubernetes-power-manager-v2.3.0
+
+helm-uninstall-v2.3.0:
 	helm uninstall kubernetes-power-manager-v2.3.0
 
 helm-install-v2.2.0: generate manifests install

--- a/README.md
+++ b/README.md
@@ -423,8 +423,8 @@ spec:
 
 The Shared PowerProfile must be created by the user and does not require a Base PowerProfile. This allows the user to
 have a Shared PowerProfile per Node in their cluster, giving more room for different configurations. The Power
-controller determines that a PowerProfile is being designated as ‘Shared’ through the use of the ‘power’ EPP value.
-
+controller determines that a PowerProfile is being designated as ‘Shared’ through the use of the ‘shared’ parameter.
+Creating a shared pool using a profile without this flag will result in undefined behavior.
 #### Example
 
 ````yaml
@@ -436,7 +436,9 @@ spec:
   name: "shared-example-node1"
   max: 1500
   min: 1000
+  shared: true
   epp: "power"
+  governor: "powersave"
 ````
 
 ````yaml
@@ -448,7 +450,9 @@ spec:
   name: "shared-example-node2"
   max: 2000
   min: 1500
-  epp: "power"
+  shared: true
+  governor: "powersave"
+
 ````
 
 ### PowerNode Controller
@@ -854,16 +858,17 @@ create the PowerProfiles that were requested on each Node.
 The example Shared PowerProfile in examples/example-shared-profile.yaml contains the following PowerProfile spec:
 
 ````yaml
-apiVersion: "power.intel.com/v1"
+apiVersion: power.intel.com/v1
 kind: PowerProfile
 metadata:
   name: shared
+  namespace: intel-power
 spec:
   name: "shared"
-  max: 1500
+  max: 1000
   min: 1000
-  # A shared PowerProfile must have the EPP value of 'power'
   epp: "power"
+  shared: true
   governor: "powersave"
 ````
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,6 +23,6 @@ FROM clearlinux@sha256:d3dd73575d2eb9c6ffb635c82b266fa9266591db844ac9f41014c0af4
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY build/manifests/ /power-manifests/
-USER 1001
+USER 10001
 
 ENTRYPOINT ["/manager"]

--- a/build/Dockerfile.nodeagent
+++ b/build/Dockerfile.nodeagent
@@ -10,7 +10,7 @@ COPY go.sum go.sum
 
 RUN go mod download
 
-ENV USER_ID=1001 \
+ENV USER_ID=10001 \
     USER_NAME=power-node-agent
 
 # Copy the go source
@@ -28,5 +28,6 @@ WORKDIR /
 COPY --from=builder /workspace/nodeagent .
 COPY build/bin bin/
 RUN bin/user_setup
+USER 10001
 
 ENTRYPOINT ["/nodeagent"]

--- a/build/manifests/power-node-agent-ds.yaml
+++ b/build/manifests/power-node-agent-ds.yaml
@@ -15,10 +15,11 @@ spec:
     spec:
       serviceAccountName: intel-power-node-agent
       containers:
-        - image: intel/power-node-agent:v2.3.0
+        - image: intel/power-node-agent:v2.3.1
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
+            runAsUser: 0
           name: power-node-agent
           args: [ "--zap-log-level","3" ]
           env:
@@ -36,7 +37,7 @@ spec:
           volumeMounts:
             - mountPath: /sys/devices/system/cpu
               name: cpusetup
-            - mountPath: /sys/fs
+            - mountPath: /sys/fs/cgroup
               name: cgroup
               readOnly: true
             - mountPath: /var/lib/kubelet/pod-resources/
@@ -48,7 +49,7 @@ spec:
             path: /sys/devices/system/cpu
         - name: cgroup
           hostPath:
-            path: /sys/fs
+            path: /sys/fs/cgroup
         - name: kubesock
           hostPath:
             path: /var/lib/kubelet/pod-resources

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,11 +24,15 @@ spec:
             - --zap-log-level
             - "3"
           imagePullPolicy: IfNotPresent
-          image: intel/power-operator:v2.3.0
+          image: intel/power-operator:v2.3.1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile:
+              type: RuntimeDefault
           name: manager
           resources:
             limits:
@@ -38,7 +42,7 @@ spec:
               cpu: 100m
               memory: 64Mi
           volumeMounts:
-            - mountPath: /sys/fs
+            - mountPath: /sys/fs/cgroup
               name: cgroup
               mountPropagation: HostToContainer
               readOnly: true
@@ -46,4 +50,4 @@ spec:
       volumes:
         - name: cgroup
           hostPath:
-            path: /sys/fs
+            path: /sys/fs/cgroup

--- a/helm/kubernetes-power-manager-v2.3.1/Chart.yaml
+++ b/helm/kubernetes-power-manager-v2.3.1/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kubernetes-power-manager-v2.3.1
+description: A Helm chart for Intel's Kubernetes Power Manager v2.3.1
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2.3.1"

--- a/helm/kubernetes-power-manager-v2.3.1/templates/_helpers.tpl
+++ b/helm/kubernetes-power-manager-v2.3.1/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubernetes-power-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubernetes-power-manager.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-power-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubernetes-power-manager.labels" -}}
+helm.sh/chart: {{ include "kubernetes-power-manager.chart" . }}
+{{ include "kubernetes-power-manager.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubernetes-power-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-power-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubernetes-power-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubernetes-power-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/kubernetes-power-manager-v2.3.1/templates/deployment.yaml
+++ b/helm/kubernetes-power-manager-v2.3.1/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Values.operator.namespace }}
+  labels:
+    control-plane: {{ .Values.operator.labels.controlplane }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: {{ .Values.operator.labels.controlplane }}
+  replicas: {{ .Values.operator.replicas }}
+  template:
+    metadata:
+      labels:
+        control-plane: {{ .Values.operator.labels.controlplane }}
+    spec:
+      serviceAccountName: {{ .Values.operator.container.serviceaccount.name }}
+      containers:
+      - command:
+        - {{ .Values.operator.container.command }}
+        args:
+        - {{ .Values.operator.container.args }}
+        imagePullPolicy: IfNotPresent
+        image: {{ .Values.operator.container.image }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        name: {{ .Values.operator.container.name }}
+        resources:
+          limits:
+            cpu: {{ .Values.operator.container.cpu.limits }}
+            memory: {{ .Values.operator.container.memory.limits }}
+          requests:
+            cpu: {{ .Values.operator.container.cpu.requests }}
+            memory: {{ .Values.operator.container.memory.requests }}
+        volumeMounts:
+        - mountPath: /sys/fs
+          name: cgroup
+          mountPropagation: HostToContainer
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cgroup
+        hostPath:
+          path: /sys/fs

--- a/helm/kubernetes-power-manager-v2.3.1/templates/namespace.yaml
+++ b/helm/kubernetes-power-manager-v2.3.1/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: {{ .Values.namespace.label }}
+  name: {{ .Values.namespace.name }}

--- a/helm/kubernetes-power-manager-v2.3.1/templates/power-config.yaml
+++ b/helm/kubernetes-power-manager-v2.3.1/templates/power-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: power.intel.com/v1
+kind: PowerConfig
+metadata:
+  name: {{ .Values.powerconfig.name }}
+  namespace: {{ .Values.powerconfig.namespace }}
+spec:
+  powerNodeSelector:
+    feature.node.kubernetes.io/power-node: "true"
+  powerProfiles:
+  - "performance"
+  - "balance-performance"
+  - "balance-power"

--- a/helm/kubernetes-power-manager-v2.3.1/templates/rbac.yaml
+++ b/helm/kubernetes-power-manager-v2.3.1/templates/rbac.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.operatorserviceaccount.name }}
+  namespace: {{ .Values.operatorserviceaccount.namespace }}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agentserviceaccount.name }}
+  namespace: {{ .Values.agentserviceaccount.namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.operatorrole.name }}
+  namespace: {{ .Values.operatorrole.namespace }}
+rules:
+- apiGroups: ["", "power.intel.com", "apps", "coordination.k8s.io"]
+  resources: ["powerconfigs", "powerconfigs/status", "powerprofiles", "powerprofiles/status", "events", "daemonsets", "configmaps", "configmaps/status", "leases", "uncores"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.operatorrolebinding.name }}
+  namespace: {{ .Values.operatorrolebinding.namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.operatorrolebinding.serviceaccount.name }}
+  namespace: {{ .Values.operatorrolebinding.serviceaccount.namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.operatorrolebinding.rolename }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.operatorclusterrole.name }}
+rules:
+- apiGroups: ["", "power.intel.com", "apps"]
+  resources: ["nodes", "nodes/status", "configmaps", "configmaps/status", "powerconfigs", "powerconfigs/status", "powerprofiles", "powerprofiles/status", "powerworkloads", "powerworkloads/status", "powernodes", "powernodes/status", "events", "daemonsets", "uncores"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.operatorclusterrolebinding.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.operatorclusterrolebinding.serviceaccount.name }}
+  namespace: {{ .Values.operatorclusterrolebinding.serviceaccount.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.operatorclusterrolebinding.clusterrolename }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.agentclusterrole.name }}
+rules:
+- apiGroups: ["", "batch", "power.intel.com"]
+  resources: ["nodes", "nodes/status", "pods", "pods/status", "cronjobs", "cronjobs/status", "powerprofiles", "powerprofiles/status", "powerworkloads", "powerworkloads/status", "powernodes", "powernodes/status", "cstates", "cstates/status", "timeofdays", "timeofdays/status", "timeofdaycronjobs", "timeofdaycronjobs/status", "uncores"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.agentclusterrolebinding.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.agentclusterrolebinding.serviceaccount.name }}
+  namespace: {{ .Values.agentclusterrolebinding.serviceaccount.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.agentclusterrolebinding.clusterrolename }}
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/kubernetes-power-manager-v2.3.1/templates/shared-power-profile.yaml
+++ b/helm/kubernetes-power-manager-v2.3.1/templates/shared-power-profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: power.intel.com/v1
+kind: PowerProfile
+metadata:
+  name: {{ .Values.sharedprofile.name }}
+  namespace: {{ .Values.sharedprofile.namespace }}
+spec:
+  name: {{ .Values.sharedprofile.spec.name }}
+  max: {{ .Values.sharedprofile.spec.max }}
+  min: {{ .Values.sharedprofile.spec.min }}
+  epp: {{ .Values.sharedprofile.spec.epp }}
+  governor: {{ .Values.sharedprofile.spec.governor }}

--- a/helm/kubernetes-power-manager-v2.3.1/values.yaml
+++ b/helm/kubernetes-power-manager-v2.3.1/values.yaml
@@ -1,0 +1,96 @@
+# Default values for kubernetes-power-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Intel Power namespace
+namespace:
+  label: controller-manager
+  name: intel-power
+
+# Service Account for the overarching operator
+operatorserviceaccount:
+  name: intel-power-operator
+  namespace: intel-power
+
+# Service Account for the Power Node Agent
+agentserviceaccount:
+  name: intel-power-node-agent
+  namespace: intel-power
+
+# Role for the overarching operator
+operatorrole:
+  name: operator-custom-resource-definitions-role
+  namespace: intel-power
+
+# Role Binding for the overarching operator
+operatorrolebinding:
+  name: operator-custom-resource-definitions-role-binding
+  namespace: intel-power
+  serviceaccount:
+    name: intel-power-operator
+    namespace: intel-power
+  rolename: operator-custom-resource-definitions-role
+
+# Cluster Role for the overarching operator
+operatorclusterrole:
+  name: operator-nodes
+
+# Cluster Role Binding for the overarching operator
+operatorclusterrolebinding:
+  name: operator-nodes-binding
+  serviceaccount:
+    name: intel-power-operator
+    namespace: intel-power
+  clusterrolename: operator-nodes
+
+# Cluster Role for the Power Node Agent
+agentclusterrole:
+  name: node-agent-cluster-resources
+
+# Cluster Role Binding for the Power Node Agent
+agentclusterrolebinding:
+  name: node-agent-cluster-resources-binding
+  serviceaccount:
+    name: intel-power-node-agent
+    namespace: intel-power
+  clusterrolename: node-agent-cluster-resources
+
+# Deployment for the overarching operator
+operator:
+  name: controller-manager
+  namespace: intel-power
+  labels:
+    controlplane: controller-manager
+  replicas: 1
+  container:
+    serviceaccount:
+      name: intel-power-operator
+    command: /manager
+    args: --enable-leader-election
+    image: intel/power-operator:v2.3.1
+    name: manager
+    cpu:
+      limits: 100m
+      requests: 100m
+    memory:
+      limits: 30Mi
+      requests: 30Mi
+
+# Values for the PowerConfig
+powerconfig:
+  name: power-config
+  namespace: intel-power
+  nodeselector:
+    label: "feature.node.kubernetes.io/power-node"
+    value: "true"
+
+# Values for the Shared PowerProfile
+sharedprofile:
+  name: shared
+  namespace: intel-power
+  spec:
+    name: "shared"
+    max: 1000
+    min: 1000
+    epp: "power"
+    governor: "powersave"


### PR DESCRIPTION
Kubernetes Power Manager v2.3.1 additions:
- Adding clarification on the "shared" profile param
- update power manager and node-agent manifests use to use image v2.3.1
- power manager and node-agent containers will be built using user 10001
- running node-agent container as root
- improving power-manager container security
- power manager and node-agent containers will now mount the more specific sys/fs/cgroup folder
- release 2.3.1 helm chart for PM