### PR TITLE
Kubernetes Power Manager v2.3.1 for OCP v4.13 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,18 +37,18 @@ build: generate manifests install
 
 # Build the Manager and Node Agent images
 images: generate manifests install
-	docker build -f build/Dockerfile -t intel/power-operator:v2.3.1 .
-	docker build -f build/Dockerfile.nodeagent -t intel/power-node-agent:v2.3.1 .
+	docker build -f build/Dockerfile -t intel/power-operator_ocp-4.13:v2.3.1 .
+	docker build -f build/Dockerfile.nodeagent -t intel/power-node-agent_ocp-4.13:v2.3.1 .
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
 	go run ./main.go
 
 helm-install: generate manifests install
-	helm install kubernetes-power-manager-v2.3.1 ./helm/kubernetes-power-manager-v2.3.1
+	helm install kubernetes-power-manager-ocp-4.13-v2.3.1 ./helm/kubernetes-power-manager-ocp-4.13-v2.3.1
 
 helm-uninstall:
-	helm uninstall kubernetes-power-manager-v2.3.1
+	helm uninstall kubernetes-power-manager-ocp-4.13-v2.3.1
 
 helm-install-v2.3.0: generate manifests install
 	helm install kubernetes-power-manager-v2.3.0 ./helm/kubernetes-power-manager-v2.3.0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,8 +19,9 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-FROM clearlinux@sha256:d3dd73575d2eb9c6ffb635c82b266fa9266591db844ac9f41014c0af415992c9
+FROM redhat/ubi9-minimal@sha256:35c99977ee5baa359bdc80f9ccc360644d2dbccb7462ca0fd97a23170a00cfd1
 WORKDIR /
+COPY LICENSE /licenses/LICENSE
 COPY --from=builder /workspace/manager .
 COPY build/manifests/ /power-manifests/
 USER 10001

--- a/build/Dockerfile.nodeagent
+++ b/build/Dockerfile.nodeagent
@@ -23,8 +23,9 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o nodeagent main.go
 
-FROM clearlinux@sha256:d3dd73575d2eb9c6ffb635c82b266fa9266591db844ac9f41014c0af415992c9
+FROM redhat/ubi9-minimal@sha256:35c99977ee5baa359bdc80f9ccc360644d2dbccb7462ca0fd97a23170a00cfd1
 WORKDIR /
+COPY LICENSE /licenses/LICENSE
 COPY --from=builder /workspace/nodeagent .
 COPY build/bin bin/
 RUN bin/user_setup

--- a/build/manifests/power-node-agent-ds.yaml
+++ b/build/manifests/power-node-agent-ds.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: intel-power-node-agent
       containers:
-        - image: intel/power-node-agent:v2.3.1
+        - image: intel/power-node-agent_ocp-4.13:v2.3.1
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
             - --zap-log-level
             - "3"
           imagePullPolicy: IfNotPresent
-          image: intel/power-operator:v2.3.1
+          image: intel/power-operator_ocp-4.13:v2.3.1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/config/rbac/rbac.yaml
+++ b/config/rbac/rbac.yaml
@@ -23,7 +23,14 @@ rules:
   - apiGroups: [ "", "power.intel.com", "apps", "coordination.k8s.io" ]
     resources: [ "powerconfigs", "powerconfigs/status", "powerprofiles", "powerprofiles/status", "events", "daemonsets", "configmaps", "configmaps/status", "leases","uncores" ]
     verbs: [ "*" ]
-
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - privileged
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -76,7 +83,14 @@ rules:
   - apiGroups: [ "", "batch", "power.intel.com" ]
     resources: [ "nodes", "nodes/status", "pods", "pods/status", "cronjobs", "cronjobs/status", "powerprofiles", "powerprofiles/status", "powerworkloads", "powerworkloads/status", "powernodes", "powernodes/status", "cstates", "cstates/status", "timeofdays", "timeofdays/status", "timeofdaycronjobs", "timeofdaycronjobs/status","uncores" ]
     verbs: [ "*" ]
-
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - privileged
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -171,3 +171,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/controllers/cstates_controller.go
+++ b/controllers/cstates_controller.go
@@ -45,6 +45,7 @@ type CStatesReconciler struct {
 
 //+kubebuilder:rbac:groups=power.intel.com,resources=cstates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=power.intel.com,resources=cstates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/powerconfig_controller.go
+++ b/controllers/powerconfig_controller.go
@@ -58,6 +58,7 @@ type PowerConfigReconciler struct {
 
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 func (r *PowerConfigReconciler) Reconcile(c context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/powernode_controller.go
+++ b/controllers/powernode_controller.go
@@ -52,6 +52,7 @@ type PowerNodeReconciler struct {
 
 // +kubebuilder:rbac:groups=power.intel.com,resources=powernodes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=power.intel.com,resources=powernodes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 func (r *PowerNodeReconciler) Reconcile(c context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/powerpod_controller.go
+++ b/controllers/powerpod_controller.go
@@ -57,6 +57,7 @@ type PowerPodReconciler struct {
 
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerpods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerpods/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 func (r *PowerPodReconciler) Reconcile(c context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/powerprofile_controller.go
+++ b/controllers/powerprofile_controller.go
@@ -81,6 +81,7 @@ type PowerProfileReconciler struct {
 
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerprofiles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerprofiles/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 // Reconcile method that implements the reconcile loop
 func (r *PowerProfileReconciler) Reconcile(c context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/powerworkload_controller.go
+++ b/controllers/powerworkload_controller.go
@@ -52,6 +52,7 @@ var sharedPowerWorkloadName = ""
 
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerworkloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=power.intel.com,resources=powerworkloads/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 func (r *PowerWorkloadReconciler) Reconcile(c context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/controllers/timeofday_controller.go
+++ b/controllers/timeofday_controller.go
@@ -48,6 +48,7 @@ type TimeOfDayReconciler struct {
 
 //+kubebuilder:rbac:groups=power.intel.com,resources=timeofdays,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=power.intel.com,resources=timeofdays/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/timeofdaycronjob_controller.go
+++ b/controllers/timeofdaycronjob_controller.go
@@ -49,6 +49,7 @@ type TimeOfDayCronJobReconciler struct {
 
 // +kubebuilder:rbac:groups=power.intel.com,resources=timeofdaycronjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=power.intel.com,resources=timeofdaycronjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by

--- a/controllers/uncore_controller.go
+++ b/controllers/uncore_controller.go
@@ -42,6 +42,7 @@ type UncoreReconciler struct {
 //+kubebuilder:rbac:groups=power.intel.com,resources=uncores,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=power.intel.com,resources=uncores/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=power.intel.com,resources=uncores/finalizers,verbs=update
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=privileged,verbs=use
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/Chart.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kubernetes-power-manager-ocp-4.13-v2.3.1
+description: A Helm chart for Intel's Kubernetes Power Manager v2.3.1 using OCP v4.13
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2.3.1"

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/Chart.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.3.1"
+appVersion: "ocp-4.13-v2.3.1"

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/_helpers.tpl
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubernetes-power-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubernetes-power-manager.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-power-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubernetes-power-manager.labels" -}}
+helm.sh/chart: {{ include "kubernetes-power-manager.chart" . }}
+{{ include "kubernetes-power-manager.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubernetes-power-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-power-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubernetes-power-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubernetes-power-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/deployment.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Values.operator.namespace }}
+  labels:
+    control-plane: {{ .Values.operator.labels.controlplane }}
+spec:
+  selector:
+    matchLabels:
+      control-plane: {{ .Values.operator.labels.controlplane }}
+  replicas: {{ .Values.operator.replicas }}
+  template:
+    metadata:
+      labels:
+        control-plane: {{ .Values.operator.labels.controlplane }}
+    spec:
+      serviceAccountName: {{ .Values.operator.container.serviceaccount.name }}
+      containers:
+      - command:
+        - {{ .Values.operator.container.command }}
+        args:
+        - {{ .Values.operator.container.args }}
+        imagePullPolicy: IfNotPresent
+        image: {{ .Values.operator.container.image }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        name: {{ .Values.operator.container.name }}
+        resources:
+          limits:
+            cpu: {{ .Values.operator.container.cpu.limits }}
+            memory: {{ .Values.operator.container.memory.limits }}
+          requests:
+            cpu: {{ .Values.operator.container.cpu.requests }}
+            memory: {{ .Values.operator.container.memory.requests }}
+        volumeMounts:
+        - mountPath: /sys/fs
+          name: cgroup
+          mountPropagation: HostToContainer
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cgroup
+        hostPath:
+          path: /sys/fs

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/namespace.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: {{ .Values.namespace.label }}
+  name: {{ .Values.namespace.name }}

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/power-config.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/power-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: power.intel.com/v1
+kind: PowerConfig
+metadata:
+  name: {{ .Values.powerconfig.name }}
+  namespace: {{ .Values.powerconfig.namespace }}
+spec:
+  powerNodeSelector:
+    feature.node.kubernetes.io/power-node: "true"
+  powerProfiles:
+  - "performance"
+  - "balance-performance"
+  - "balance-power"

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/rbac.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/rbac.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.operatorserviceaccount.name }}
+  namespace: {{ .Values.operatorserviceaccount.namespace }}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agentserviceaccount.name }}
+  namespace: {{ .Values.agentserviceaccount.namespace }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.operatorrole.name }}
+  namespace: {{ .Values.operatorrole.namespace }}
+rules:
+- apiGroups: ["", "power.intel.com", "apps", "coordination.k8s.io"]
+  resources: ["powerconfigs", "powerconfigs/status", "powerprofiles", "powerprofiles/status", "events", "daemonsets", "configmaps", "configmaps/status", "leases", "uncores"]
+  verbs: ["*"]
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.operatorrolebinding.name }}
+  namespace: {{ .Values.operatorrolebinding.namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.operatorrolebinding.serviceaccount.name }}
+  namespace: {{ .Values.operatorrolebinding.serviceaccount.namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.operatorrolebinding.rolename }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.operatorclusterrole.name }}
+rules:
+- apiGroups: ["", "power.intel.com", "apps"]
+  resources: ["nodes", "nodes/status", "configmaps", "configmaps/status", "powerconfigs", "powerconfigs/status", "powerprofiles", "powerprofiles/status", "powerworkloads", "powerworkloads/status", "powernodes", "powernodes/status", "events", "daemonsets", "uncores"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.operatorclusterrolebinding.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.operatorclusterrolebinding.serviceaccount.name }}
+  namespace: {{ .Values.operatorclusterrolebinding.serviceaccount.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.operatorclusterrolebinding.clusterrolename }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.agentclusterrole.name }}
+rules:
+- apiGroups: ["", "batch", "power.intel.com"]
+  resources: ["nodes", "nodes/status", "pods", "pods/status", "cronjobs", "cronjobs/status", "powerprofiles", "powerprofiles/status", "powerworkloads", "powerworkloads/status", "powernodes", "powernodes/status", "cstates", "cstates/status", "timeofdays", "timeofdays/status", "timeofdaycronjobs", "timeofdaycronjobs/status", "uncores"]
+  verbs: ["*"]
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.agentclusterrolebinding.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.agentclusterrolebinding.serviceaccount.name }}
+  namespace: {{ .Values.agentclusterrolebinding.serviceaccount.namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.agentclusterrolebinding.clusterrolename }}
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/shared-power-profile.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/templates/shared-power-profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: power.intel.com/v1
+kind: PowerProfile
+metadata:
+  name: {{ .Values.sharedprofile.name }}
+  namespace: {{ .Values.sharedprofile.namespace }}
+spec:
+  name: {{ .Values.sharedprofile.spec.name }}
+  max: {{ .Values.sharedprofile.spec.max }}
+  min: {{ .Values.sharedprofile.spec.min }}
+  epp: {{ .Values.sharedprofile.spec.epp }}
+  governor: {{ .Values.sharedprofile.spec.governor }}

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/values.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/values.yaml
@@ -1,0 +1,96 @@
+# Default values for kubernetes-power-manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Intel Power namespace
+namespace:
+  label: controller-manager
+  name: intel-power
+
+# Service Account for the overarching operator
+operatorserviceaccount:
+  name: intel-power-operator
+  namespace: intel-power
+
+# Service Account for the Power Node Agent
+agentserviceaccount:
+  name: intel-power-node-agent
+  namespace: intel-power
+
+# Role for the overarching operator
+operatorrole:
+  name: operator-custom-resource-definitions-role
+  namespace: intel-power
+
+# Role Binding for the overarching operator
+operatorrolebinding:
+  name: operator-custom-resource-definitions-role-binding
+  namespace: intel-power
+  serviceaccount:
+    name: intel-power-operator
+    namespace: intel-power
+  rolename: operator-custom-resource-definitions-role
+
+# Cluster Role for the overarching operator
+operatorclusterrole:
+  name: operator-nodes
+
+# Cluster Role Binding for the overarching operator
+operatorclusterrolebinding:
+  name: operator-nodes-binding
+  serviceaccount:
+    name: intel-power-operator
+    namespace: intel-power
+  clusterrolename: operator-nodes
+
+# Cluster Role for the Power Node Agent
+agentclusterrole:
+  name: node-agent-cluster-resources
+
+# Cluster Role Binding for the Power Node Agent
+agentclusterrolebinding:
+  name: node-agent-cluster-resources-binding
+  serviceaccount:
+    name: intel-power-node-agent
+    namespace: intel-power
+  clusterrolename: node-agent-cluster-resources
+
+# Deployment for the overarching operator
+operator:
+  name: controller-manager
+  namespace: intel-power
+  labels:
+    controlplane: controller-manager
+  replicas: 1
+  container:
+    serviceaccount:
+      name: intel-power-operator
+    command: /manager
+    args: --enable-leader-election
+    image: silpixa00401508d.ir.intel.com:5000/power-operator_ocp-4.13:v2.3.1
+    name: manager
+    cpu:
+      limits: 100m
+      requests: 100m
+    memory:
+      limits: 30Mi
+      requests: 30Mi
+
+# Values for the PowerConfig
+powerconfig:
+  name: power-config
+  namespace: intel-power
+  nodeselector:
+    label: "feature.node.kubernetes.io/power-node"
+    value: "true"
+
+# Values for the Shared PowerProfile
+sharedprofile:
+  name: shared
+  namespace: intel-power
+  spec:
+    name: "shared"
+    max: 1000
+    min: 1000
+    epp: "power"
+    governor: "powersave"

--- a/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/values.yaml
+++ b/helm/kubernetes-power-manager-ocp-4.13-v2.3.1/values.yaml
@@ -67,7 +67,7 @@ operator:
       name: intel-power-operator
     command: /manager
     args: --enable-leader-election
-    image: silpixa00401508d.ir.intel.com:5000/power-operator_ocp-4.13:v2.3.1
+    image: intel/power-operator_ocp-4.13:v2.3.1
     name: manager
     cpu:
       limits: 100m


### PR DESCRIPTION
Kubernetes Power Manager v2.3.1 for OCP 4.13 additions:
  - OCP 4.13 images will be built using UBI9:minimal as a base image instead of clearlinux
  - manager and node-agent manifests use the _ocp-4.13 images
  - running the RH preflight required changes to the dockerfiles(manager, node-agent):
    - - copy LICENSE files to /licenses folder
  - attach the 'privileged' SCC to both node-agent and PM images By default, in OCP 4.13, restricted-v2 is the default SCC (security context constraint). This SCC with it's default permissions are too restrictive for PM and NA pods.
  - create power-manager-ocp-4.13-v2.3.1 helm chart