### PR TITLE
Updating typo in power-workload docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ spec:
   allCores: true
   reservedCPUs:
     - cores: [0, 1]
-      profile: "performance"
+      powerProfile: "performance"
   powerNodeSelector:
     # Labels other than hostname can be used
     - “kubernetes.io/hostname”: “example-node”


### PR DESCRIPTION
### Summary
As mentioned in https://github.com/intel/kubernetes-power-manager/pull/74#discussion_r1496543315, the docs were updated with the correct field name