### PR TITLE
fix: update default values in helm (#151)

### DIFF
--- a/helm/kubernetes-power-manager/Chart.yaml
+++ b/helm/kubernetes-power-manager/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: kubernetes-power-manager-v2.3.1
+name: kubernetes-power-manager
 description: A Helm chart for Intel's Kubernetes Power Manager
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/helm/kubernetes-power-manager/values.yaml
+++ b/helm/kubernetes-power-manager/values.yaml
@@ -69,7 +69,7 @@ operator:
       name: intel-power-operator
     command: /manager
     args: --enable-leader-election
-    image: intel/power-operator:v2.3.1
+    image: intel/power-operator:v2.4.0
     name: manager
     cpu:
       limits: 100m


### PR DESCRIPTION
Removing version from helm chart name and updating default image to 2.4.0.
**Note:** the intended way to use the helm charts is through the Makefile meaning this change is purely cosmetic to keep things up to date and avoid confusion. Values like chart name, version and image get replaced during the ``make helm-install`` command